### PR TITLE
chore: add ci workflow to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI - Test & Coverage
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_ENV: test
+      PORT: 3000
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRES_IN: 1h
+      MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      DB_NAME: test
+      BCRYPT_SALT_ROUNDS: 10
+      CORS_ORIGIN: http://localhost:3000
+      EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
+      EMAIL_PORT: ${{ secrets.EMAIL_PORT }}
+      EMAIL_USER: ${{ secrets.EMAIL_USER }}
+      EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm test
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -147,6 +147,36 @@ All errors are returned in a consistent JSON format:
 - Database connections are automatically managed
 - All API responses follow a consistent structure
 
+## CI/CD Pipeline
+
+This project includes a simple GitHub Actions workflow for continuous integration:
+
+### CI Workflow
+
+The CI workflow (`.github/workflows/ci.yml`) runs on:
+
+- Push to `main` and `develop` branches
+- Pull requests to `main` and `develop` branches
+
+**What it does:**
+
+- ✅ Installs dependencies
+- ✅ Runs all tests with coverage
+- ✅ Uploads coverage reports as GitHub artifacts
+
+### Coverage Reports
+
+Test coverage reports are automatically generated and uploaded as GitHub artifacts. You can download and view them in the GitHub Actions tab after each run.
+
+### Local Testing
+
+Before pushing, run tests locally:
+
+```bash
+npm install
+npm test
+```
+
 ## Next Steps
 
 To complete the authentication service, consider implementing:
@@ -156,7 +186,6 @@ To complete the authentication service, consider implementing:
 - Email verification
 - Rate limiting
 - Logging framework
-- Unit and integration tests
 - API documentation with Swagger/OpenAPI
 
 ## Troubleshooting


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for continuous integration (CI) and updates the project's documentation to reflect these changes. The most important updates include adding a CI workflow file, enhancing the `README.md` documentation with details about the CI pipeline, and removing outdated references to testing in the "Next Steps" section.

### CI Workflow Addition:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R34): Introduced a new CI workflow that runs on pushes and pull requests to the `main` and `develop` branches. It installs dependencies, runs tests with coverage, and uploads coverage reports as GitHub artifacts.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R150-R179): Added a new section detailing the CI/CD pipeline, including the purpose of the CI workflow, how it operates, and instructions for local testing.

### Cleanup:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L159): Removed the outdated mention of "Unit and integration tests" from the "Next Steps" section, as testing is now part of the CI workflow.