### PR TITLE
chore: add ci workflow to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: ci
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_ENV: test
+      PORT: 3000
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRES_IN: 1h
+      MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      DB_NAME: test
+      BCRYPT_SALT_ROUNDS: 10
+      CORS_ORIGIN: http://localhost:3000
+      EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
+      EMAIL_PORT: ${{ secrets.EMAIL_PORT }}
+      EMAIL_USER: ${{ secrets.EMAIL_USER }}
+      EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
+      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm test
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![ci](https://github.com/ericndungutse/ijwi-auth-service/actions/workflows/ci.yml/badge.svg)](https://github.com/ericndungutse/ijwi-auth-service/actions/workflows/ci.yml)
+
 # Auth Service
 
 A Node.js authentication service built with Express, TypeScript, and MongoDB.
@@ -147,6 +149,36 @@ All errors are returned in a consistent JSON format:
 - Database connections are automatically managed
 - All API responses follow a consistent structure
 
+## CI/CD Pipeline
+
+This project includes a simple GitHub Actions workflow for continuous integration:
+
+### CI Workflow
+
+The CI workflow (`.github/workflows/ci.yml`) runs on:
+
+- Push to `main` and `develop` branches
+- Pull requests to `main` and `develop` branches
+
+**What it does:**
+
+- ✅ Installs dependencies
+- ✅ Runs all tests with coverage
+- ✅ Uploads coverage reports as GitHub artifacts
+
+### Coverage Reports
+
+Test coverage reports are automatically generated and uploaded as GitHub artifacts. You can download and view them in the GitHub Actions tab after each run.
+
+### Local Testing
+
+Before pushing, run tests locally:
+
+```bash
+npm install
+npm test
+```
+
 ## Next Steps
 
 To complete the authentication service, consider implementing:
@@ -156,7 +188,6 @@ To complete the authentication service, consider implementing:
 - Email verification
 - Rate limiting
 - Logging framework
-- Unit and integration tests
 - API documentation with Swagger/OpenAPI
 
 ## Troubleshooting


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow for continuous integration (CI) and updates the project documentation to reflect these changes. The CI workflow automates testing, coverage reporting, and artifact upload processes, enhancing the development pipeline. Additionally, the README has been updated to include details about the CI pipeline and local testing instructions, while removing outdated references to testing in the "Next Steps" section.

### CI/CD Pipeline Implementation:

* Added a new GitHub Actions workflow (`.github/workflows/ci.yml`) to automate testing and coverage reporting for pushes and pull requests to the `main` and `develop` branches. The workflow includes steps for dependency installation, running tests, and uploading coverage reports as artifacts.

### Documentation Updates:

* Updated the README to include a new "CI/CD Pipeline" section, describing the CI workflow, its triggers, and the coverage report upload process. Also added instructions for running tests locally.
* Removed "Unit and integration tests" from the "Next Steps" section in the README, as these are now covered by the CI pipeline.