### PR TITLE
feat: initial commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,6 @@ jobs:
       NODE_ENV: test
       PORT: 3000
       JWT_SECRET: ${{ secrets.JWT_SECRET }}
-      JWT_EXPIRES_IN: 1h
-      MONGODB_URI: ${{ secrets.MONGODB_URI }}
-      DB_NAME: test
-      BCRYPT_SALT_ROUNDS: 10
-      CORS_ORIGIN: http://localhost:3000
-      EMAIL_HOST: ${{ secrets.EMAIL_HOST }}
-      EMAIL_PORT: ${{ secrets.EMAIL_PORT }}
-      EMAIL_USER: ${{ secrets.EMAIL_USER }}
-      EMAIL_PASS: ${{ secrets.EMAIL_PASS }}
-      EMAIL_FROM: ${{ secrets.EMAIL_FROM }}
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This pull request simplifies the CI workflow configuration by removing unused environment variables from the `jobs` section in `.github/workflows/ci.yml`.

### CI Workflow Simplification:
* Removed the following environment variables: `JWT_EXPIRES_IN`, `MONGODB_URI`, `DB_NAME`, `BCRYPT_SALT_ROUNDS`, `CORS_ORIGIN`, `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER`, `EMAIL_PASS`, and `EMAIL_FROM`, as they are no longer required for the CI process (`.github/workflows/ci.yml`, [.github/workflows/ci.ymlL17-L26](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-L26)).