### PR TITLE
feat: logout

### DIFF
--- a/__tests__/integration/logout.test.ts
+++ b/__tests__/integration/logout.test.ts
@@ -1,0 +1,388 @@
+import mongoose from 'mongoose';
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from '@jest/globals';
+import supertest from 'supertest';
+import { App } from '../../src/app';
+import { Account } from '../../src/models/account/account.model';
+
+// Mock EmailService to avoid sending real emails during tests
+jest.mock('../../src/services/impl/EmailService', () => {
+  return {
+    EmailService: jest.fn().mockImplementation(() => ({
+      sendEmail: jest.fn().mockResolvedValue(true),
+      sendVerificationEmail: jest.fn().mockResolvedValue(true),
+      sendPasswordResetEmail: jest.fn().mockResolvedValue(true),
+    })),
+  };
+});
+
+let mongoServer: MongoMemoryServer;
+let app: App;
+let server: any;
+
+beforeAll(async () => {
+  mongoServer = await MongoMemoryServer.create();
+  const uri = mongoServer.getUri('test');
+  await mongoose.connect(uri);
+
+  app = new App();
+  server = app.getApp();
+});
+
+afterAll(async () => {
+  await mongoose.disconnect();
+  await mongoServer.stop();
+});
+
+beforeEach(async () => {
+  // Clear all collections before each test
+  const collections = mongoose.connection.collections;
+  for (const key in collections) {
+    const collection = collections[key];
+    await collection.deleteMany({});
+  }
+});
+
+describe('Logout Integration Tests', () => {
+  describe('GET /api/v1/auth/logout', () => {
+    it('should return 401 for unauthenticated requests', async () => {
+      const response = await supertest(server).get('/api/v1/auth/logout').set('x-client-type', 'web');
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.errors[0].message).toContain('No JWT token provided');
+    });
+
+    it('should return 401 for invalid JWT token', async () => {
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', 'jwt=invalid-token');
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+    });
+
+    it('should return 401 for expired JWT token', async () => {
+      // Mock an expired token
+      const expiredToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjY1ZjJhMjEyMzQ1Njc4OTBhYmNkZWYiLCJlbWFpbCI6InRlc3RAZXhhbXBsZS5jb20iLCJyb2xlIjoidXNlciIsImlhdCI6MTcwMzY5NjAwMCwiZXhwIjoxNzAzNjk2MDAwfQ.invalid';
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${expiredToken}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+    });
+
+    it('should return 401 for non-existent user', async () => {
+      // Create a user, generate token, then delete the user
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+      await Account.findByIdAndDelete(user._id);
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.errors[0].message).toBe('User no longer exists.');
+    });
+
+    it('should return 401 for inactive user', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: false, // Inactive user
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.errors[0].message).toBe('User account is deactivated.');
+    });
+
+    it('should return 401 for unverified email', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: false, // Unverified email
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.errors[0].message).toBe(
+        'Email not verified. Please verify your email before accessing protected routes.'
+      );
+    });
+
+    it('should successfully logout web client and clear JWT cookie', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.message).toBe('Logged out successfully');
+      expect(response.body.data).toBeNull();
+
+      // Check that the JWT cookie is cleared
+      const cookies = response.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+
+      if (Array.isArray(cookies)) {
+        const jwtCookie = cookies.find((cookie: string) => cookie.startsWith('jwt='));
+        expect(jwtCookie).toBeDefined();
+        expect(jwtCookie).toContain('Max-Age=0');
+        expect(jwtCookie).toContain('HttpOnly');
+        expect(jwtCookie).toContain('Secure');
+        expect(jwtCookie).toContain('SameSite=None');
+      } else if (typeof cookies === 'string') {
+        expect(cookies).toContain('jwt=');
+        expect(cookies).toContain('Max-Age=0');
+        expect(cookies).toContain('HttpOnly');
+        expect(cookies).toContain('Secure');
+        expect(cookies).toContain('SameSite=None');
+      }
+    });
+
+    it('should successfully logout with undefined client type (defaults to web)', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server).get('/api/v1/auth/logout').set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.message).toBe('Logged out successfully');
+
+      // Check that the JWT cookie is cleared
+      const cookies = response.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+
+      if (Array.isArray(cookies)) {
+        const jwtCookie = cookies.find((cookie: string) => cookie.startsWith('jwt='));
+        expect(jwtCookie).toBeDefined();
+        expect(jwtCookie).toContain('Max-Age=0');
+      } else if (typeof cookies === 'string') {
+        expect(cookies).toContain('jwt=');
+        expect(cookies).toContain('Max-Age=0');
+      }
+    });
+
+    it('should return 400 for mobile client type', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'mobile')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(400);
+      expect(response.body.status).toBe('fail');
+      expect(response.body.message).toBe('Logout failed.');
+      expect(response.body.errors[0].message).toBe('Logout failed. Mobile clients logout is not supported.');
+    });
+
+    it('should work with Authorization header instead of cookie', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.message).toBe('Logged out successfully');
+
+      // Should still clear the cookie even when using Authorization header
+      const cookies = response.headers['set-cookie'];
+      expect(cookies).toBeDefined();
+
+      if (Array.isArray(cookies)) {
+        const jwtCookie = cookies.find((cookie: string) => cookie.startsWith('jwt='));
+        expect(jwtCookie).toBeDefined();
+        expect(jwtCookie).toContain('Max-Age=0');
+      } else if (typeof cookies === 'string') {
+        expect(cookies).toContain('jwt=');
+        expect(cookies).toContain('Max-Age=0');
+      }
+    });
+
+    it('should handle multiple logout requests for the same user', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      // First logout
+      const response1 = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response1.status).toBe(200);
+      expect(response1.body.status).toBe('success');
+
+      // Second logout with same token should also succeed (token is still valid, cookie is cleared)
+      const response2 = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', `jwt=${token}`);
+
+      expect(response2.status).toBe(200);
+      expect(response2.body.status).toBe('success');
+    });
+
+    it('should handle malformed JWT token', async () => {
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', 'jwt=malformed.jwt.token');
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+    });
+
+    it('should handle empty JWT token', async () => {
+      const response = await supertest(server)
+        .get('/api/v1/auth/logout')
+        .set('x-client-type', 'web')
+        .set('Cookie', 'jwt=');
+
+      expect(response.status).toBe(401);
+      expect(response.body.status).toBe('fail');
+    });
+
+    it('should handle missing x-client-type header', async () => {
+      const user = new Account({
+        email: 'test@example.com',
+        password: 'password123',
+        userName: 'testuser',
+        emailVerification: {
+          verified: true,
+          code: 123456,
+        },
+        isActive: true,
+        role: 'user',
+      });
+      await user.save();
+
+      const token = await user.generateJwt();
+
+      const response = await supertest(server).get('/api/v1/auth/logout').set('Cookie', `jwt=${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.status).toBe('success');
+      expect(response.body.message).toBe('Logged out successfully');
+    });
+  });
+});

--- a/__tests__/unit/AccountController.unit.test.ts
+++ b/__tests__/unit/AccountController.unit.test.ts
@@ -320,4 +320,180 @@ describe('AccountController', () => {
       expect(mockNext).toHaveBeenCalledWith(error);
     });
   });
+
+  describe('logout', () => {
+    it('should clear JWT cookie for web clients', async () => {
+      const mockRequest = {
+        headers: {
+          'x-client-type': 'web',
+        },
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith('jwt', '', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        maxAge: 0,
+      });
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'Logged out successfully',
+        data: null,
+      });
+    });
+
+    it('should return 400 error for mobile clients', async () => {
+      const mockRequest = {
+        headers: {
+          'x-client-type': 'mobile',
+        },
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockResponse.cookie).not.toHaveBeenCalled();
+      expect(mockResponse.status).toHaveBeenCalledWith(400);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'fail',
+        message: 'Logout failed.',
+        errors: [{ message: 'Logout failed. Mobile clients logout is not supported.' }],
+      });
+    });
+
+    it('should handle undefined client type as web client', async () => {
+      const mockRequest = {
+        headers: {},
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith('jwt', '', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        maxAge: 0,
+      });
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'Logged out successfully',
+        data: null,
+      });
+    });
+
+    it('should handle null client type as web client', async () => {
+      const mockRequest = {
+        headers: {
+          'x-client-type': null,
+        },
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith('jwt', '', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        maxAge: 0,
+      });
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'Logged out successfully',
+        data: null,
+      });
+    });
+
+    it('should handle empty string client type as web client', async () => {
+      const mockRequest = {
+        headers: {
+          'x-client-type': '',
+        },
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockResponse.cookie).toHaveBeenCalledWith('jwt', '', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        maxAge: 0,
+      });
+
+      expect(mockResponse.status).toHaveBeenCalledWith(200);
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        status: 'success',
+        message: 'Logged out successfully',
+        data: null,
+      });
+    });
+
+    it('should handle error and call next', async () => {
+      const mockRequest = {
+        headers: {
+          'x-client-type': 'web',
+        },
+      } as any;
+
+      const mockResponse = {
+        cookie: jest.fn().mockImplementation(() => {
+          throw new Error('Cookie error');
+        }),
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      } as any;
+
+      const mockNext = jest.fn();
+
+      await controller.logout(mockRequest, mockResponse, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith(expect.any(Error));
+    });
+  });
 });

--- a/src/controllers/AccountController.ts
+++ b/src/controllers/AccountController.ts
@@ -205,4 +205,40 @@ export class AccountController {
       next(error);
     }
   }
+
+  async logout(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      // Check for client type header
+      const clientType = req.headers['x-client-type'] as 'mobile' | 'web' | undefined;
+
+      console.log('clientType', clientType);
+
+      // Reject if client type is mobile
+      if (clientType === 'mobile') {
+        const response: ApiResponse<null, { message: string }[]> = {
+          status: 'fail',
+          message: 'Logout failed.',
+          errors: [{ message: 'Logout failed. Mobile clients logout is not supported.' }],
+        };
+        res.status(400).json(response);
+        return;
+      }
+
+      res.cookie('jwt', '', {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'none',
+        maxAge: 0, // This immediately expires the cookie
+      });
+
+      const response: ApiResponse<null, null> = {
+        status: 'success',
+        message: 'Logged out successfully',
+        data: null,
+      };
+      res.status(200).json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
 }

--- a/src/routes/account.routes.ts
+++ b/src/routes/account.routes.ts
@@ -2,6 +2,7 @@ import { NextFunction, Request, Response } from 'express';
 
 const express = require('express');
 const { container } = require('../infrastructure/container');
+const { authenticate } = require('../middleware/authenticate');
 
 const accountRouter = express.Router();
 
@@ -18,6 +19,10 @@ accountRouter.patch('/verify-email', (req: Request, res: Response, next: NextFun
 
 accountRouter.post('/forgot-password', (req: Request, res: Response, next: NextFunction) =>
   container.accountController.forgotPassword(req, res, next)
+);
+
+accountRouter.get('/logout', authenticate, (req: Request, res: Response, next: NextFunction) =>
+  container.accountController.logout(req, res, next)
 );
 
 module.exports = accountRouter;


### PR DESCRIPTION
This pull request introduces a logout feature for the `AccountController`, including both implementation and comprehensive testing. The feature ensures secure logout functionality for web clients, while explicitly rejecting logout requests from mobile clients. Key changes include the addition of the `logout` method in the `AccountController`, integration of the logout route, and extensive unit and integration tests to validate various scenarios.

### Logout Feature Implementation:

* **`src/controllers/AccountController.ts`**: Added a new `logout` method that clears the JWT cookie for web clients, rejects mobile client logout requests, and handles potential errors.

* **`src/routes/account.routes.ts`**:
  - Imported the `authenticate` middleware to secure the logout route.
  - Added a new `GET /logout` route that invokes the `logout` method in the `AccountController`.

### Testing Enhancements:

* **Integration Tests (`__tests__/integration/logout.test.ts`)**:
  - Added comprehensive tests to cover various logout scenarios, including successful logout for web clients, rejection for mobile clients, handling of invalid or expired tokens, and edge cases like missing or malformed JWTs.

* **Unit Tests (`__tests__/unit/AccountController.unit.test.ts`)**:
  - Added unit tests for the `logout` method to verify behavior for different client types and ensure proper error handling.